### PR TITLE
Set access details properly when creating queues

### DIFF
--- a/lib/Amazon/SQS/Simple.pm
+++ b/lib/Amazon/SQS/Simple.pm
@@ -20,7 +20,9 @@ sub GetQueue {
 		$queue_endpoint = "https://sqs.$host.amazonaws.com/$user/$queue";
 	}
 
-    return new Amazon::SQS::Simple::Queue(
+    return Amazon::SQS::Simple::Queue->new(
+        $self->{AWSAccessKeyId},	#AWSAccessKeyId and SecretKey are the first two arguments to Amazon::SQS::Simple::Base->new
+        $self->{SecretKey},
         %$self,
         Endpoint => $queue_endpoint,
     );
@@ -36,6 +38,8 @@ sub CreateQueue {
     
     if ($href->{CreateQueueResult}{QueueUrl}) {
         return Amazon::SQS::Simple::Queue->new(
+            $self->{AWSAccessKeyId},	#AWSAccessKeyId and SecretKey are the first two arguments to Amazon::SQS::Simple::Base->new
+            $self->{SecretKey},
             %$self,
             Endpoint => $href->{CreateQueueResult}{QueueUrl},
         );
@@ -52,7 +56,9 @@ sub ListQueues {
     # default to the current version
     if ($href->{ListQueuesResult}{QueueUrl}) {
         my @result = map {
-            new Amazon::SQS::Simple::Queue(
+            Amazon::SQS::Simple::Queue->new(
+                $self->{AWSAccessKeyId},	#AWSAccessKeyId and SecretKey are the first two arguments to Amazon::SQS::Simple::Base->new
+                $self->{SecretKey},
                 %$self,
                 Endpoint => $_,
             )        


### PR DESCRIPTION
The queue creation process goes through ...Base->new which expects the first two
parameters to be the access key and the secret key, but it had been receiving a
hash which meant the first argument was a hash key, with the second being the
corresponding value - if the first key was 'Version' or similar, this was ok,
because the access details later in the hash would properly stomp it, but if
the access key was first up it would set the AWSAccessKeyId field in the new
queue to the string 'AWSAccessKeyId' with no ability to stomp it later.
Randomisation of the hash keys means that this was a somewhat difficult to
reproduce problem (and it's possible that the more consistent randomisation
system in earlier versions of perl would never actually have the access key as
the first value).