### PR TITLE
Dispatch tries

### DIFF
--- a/lib/Amazon/SQS/Simple/Base.pm
+++ b/lib/Amazon/SQS/Simple/Base.pm
@@ -98,7 +98,9 @@ sub _dispatch {
     $self->_debug_log($query);
 
 	my $try;
-	foreach $try (1..3) {	
+	foreach (1..3) {	
+        $try = $_;
+
 	    if ($post_request) {
 	        $response = $ua->post(
 	            $url, 

--- a/lib/Amazon/SQS/Simple/Base.pm
+++ b/lib/Amazon/SQS/Simple/Base.pm
@@ -97,38 +97,38 @@ sub _dispatch {
 
     $self->_debug_log($query);
 
-	my $try;
-	foreach (1..3) {	
+    my $try;
+    foreach (1..3) {
         $try = $_;
 
-	    if ($post_request) {
-	        $response = $ua->post(
-	            $url, 
-	            'Content-Type' => 'application/x-www-form-urlencoded;charset=utf-8',
-	            'Content'      => $query,
-	            @auth_headers,
-	        );
-	    }
-	    else {
-	        $response = $ua->get("$url/?$query", "Content-Type" => "text/plain;charset=utf-8", @auth_headers);
-	    }
+        if ($post_request) {
+            $response = $ua->post(
+                $url, 
+                'Content-Type' => 'application/x-www-form-urlencoded;charset=utf-8',
+                'Content'      => $query,
+                @auth_headers,
+            );
+        }
+        else {
+            $response = $ua->get("$url/?$query", "Content-Type" => "text/plain;charset=utf-8", @auth_headers);
+        }
         
-		# $response isa HTTP::Response
-		
-	    if ($response->is_success) {
-	        $self->_debug_log($response->content);
-	        my $href = XMLin($response->content, ForceArray => $force_array, KeyAttr => {});
-	        return $href;
-	    }
-	
-		# advice from internal AWS support - most client libraries try 3 times in the face
-		# of 500 errors, so ours should too
-		
-		next if ($response->code == 500);
+        # $response isa HTTP::Response
+        
+        if ($response->is_success) {
+            $self->_debug_log($response->content);
+            my $href = XMLin($response->content, ForceArray => $force_array, KeyAttr => {});
+            return $href;
+        }
+    
+        # advice from internal AWS support - most client libraries try 3 times in the face
+        # of 500 errors, so ours should too
+        
+        next if ($response->code == 500);
      }
 
-	 # if we fall out of the loop, then we have either a non-500 error or a persistent 500.
-	
+     # if we fall out of the loop, then we have either a non-500 error or a persistent 500.
+    
      my $msg;
      eval {
          my $href = XMLin($response->content);


### PR DESCRIPTION
The variable $try was returning to its undefined value upon exiting the loop, on an error the debug statement on line 136 was throwing a "Use of uninitialized value" error for $try.  I also changed the handful of tabbed whitespace in this file to be 4 spaces as that seemed to be the otherwise consistent usage.

Perl perlsyn: "the variable is implicitly local to the loop and regains its former value upon exiting the loop. If the variable was previously declared with my, it uses that variable instead of the global one, but it's still localized to the loop. This implicit localization occurs only in a foreach loop."

http://perldoc.perl.org/perlsyn.html#Foreach-Loops
