### PR TITLE
Added missing module import

### DIFF
--- a/Changes
+++ b/Changes
@@ -79,5 +79,8 @@ Revision history for Amazon-SQS-Simple
         Better tracking of retries (cjhamil)
         Retry 503s as well (Chris Jones)
         
-2.06    20 May 2017
+2.06    20 Mar 2017
         Fix 500/503 retry code so it actually works
+
+2.07    30 Mar 2017
+        Added missing module import (Sachin Sebastian)

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -16,6 +16,7 @@ WriteMakefile(
         'Digest::SHA'       => 0,
         'LWP::UserAgent'    => 0,
         'MIME::Base64'      => 0,
+        'Time::HiRes'       => 0,
         'URI::Escape'       => 0,
         'XML::Simple'       => 0,
         'VM::EC2::Security::CredentialCache' => 0,

--- a/lib/Amazon/SQS/Simple/Base.pm
+++ b/lib/Amazon/SQS/Simple/Base.pm
@@ -15,6 +15,7 @@ use AWS::Signature4;
 use POSIX qw(strftime);
 use Encode qw(encode);
 use Data::Dumper;
+use Time::HiRes;
 use VM::EC2::Security::CredentialCache;
 
 use base qw(Exporter);


### PR DESCRIPTION
Time::HiRes is not used in Amazon::SQS::Simple::Base and it was throwing an error. 