### PR TITLE
Prevent double encoding

### DIFF
--- a/lib/Amazon/SQS/Simple/Base.pm
+++ b/lib/Amazon/SQS/Simple/Base.pm
@@ -169,6 +169,8 @@ sub _debug_log {
 
 sub _escape_params {
     my ($self, $params) = @_;
+	
+    my $escaped_params = {};
 
     # Need to escape + characters in signature
     # see http://docs.amazonwebservices.com/AWSSimpleQueueService/2006-04-01/Query_QueryAuth.html
@@ -181,9 +183,9 @@ sub _escape_params {
     foreach my $key (keys %$params) {
         next unless $key =~ m/$to_escape/;
         my $octets = encode('utf-8-strict', $params->{$key});
-        $params->{$key} = uri_escape($octets, $URI_SAFE_CHARACTERS);
+        $escaped_params->{$key} = uri_escape($octets, $URI_SAFE_CHARACTERS);
     }
-    return $params;
+    return $escaped_params;
 }
 
 sub _escape_param {

--- a/lib/Amazon/SQS/Simple/Base.pm
+++ b/lib/Amazon/SQS/Simple/Base.pm
@@ -170,7 +170,7 @@ sub _debug_log {
 sub _escape_params {
     my ($self, $params) = @_;
 	
-    my $escaped_params = {};
+    my $escaped_params = {%$params};
 
     # Need to escape + characters in signature
     # see http://docs.amazonwebservices.com/AWSSimpleQueueService/2006-04-01/Query_QueryAuth.html


### PR DESCRIPTION
Each time this module retries, the message gets encoded an additional time. This results in double, triple, etc encoding. Otherwise, this is a great module!